### PR TITLE
For #171: Reservation duration calculation

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -181,33 +181,6 @@ def test_new_customer():
         customer.phone_number == phone_number
     )
 
-def test_new_reservation():
-    start_time = datetime.utcnow()
-    end_time = datetime.utcnow()
-    duration = datetime.utcnow().time()
-    customer_id = 1
-    num_of_persons = 4
-    comment = "My comment"
-    status = ReservationStatus.confirmed
-    new_reservation = Reservation(
-        start_time=start_time,
-        end_time=end_time,
-        duration=duration,
-        customer_id=customer_id,
-        num_of_persons=num_of_persons,
-        comment=comment,
-        status=status
-    )
-    assert (
-        new_reservation.start_time == start_time and
-        new_reservation.end_time == end_time and
-        new_reservation.duration == duration and
-        new_reservation.customer_id == customer_id and
-        new_reservation.num_of_persons == num_of_persons and
-        new_reservation.comment == comment and
-        new_reservation.status == status
-    )
-
 def test_new_item():
     id = 1
     name = "First Item"

--- a/tests/test_reservation.py
+++ b/tests/test_reservation.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from timeless.restaurants.models import ReservationStatus, Reservation
+
+"""Tests for Reservation 
+
+"""
+
+def test_new_reservation():
+    start_time = datetime.utcnow()
+    end_time = datetime.utcnow()
+    customer_id = 1
+    num_of_persons = 4
+    comment = "My comment"
+    status = ReservationStatus.confirmed
+    new_reservation = Reservation(
+        start_time=start_time,
+        end_time=end_time,
+        customer_id=customer_id,
+        num_of_persons=num_of_persons,
+        comment=comment,
+        status=status
+    )
+    assert (
+        new_reservation.start_time == start_time and
+        new_reservation.end_time == end_time and
+        new_reservation.customer_id == customer_id and
+        new_reservation.num_of_persons == num_of_persons and
+        new_reservation.comment == comment and
+        new_reservation.status == status
+    )
+
+def test_reservation_duration():
+    start_time = datetime.utcnow()
+    end_time = datetime.utcnow()
+    customer_id = 5
+    num_of_persons = 4
+    comment = "This is a reservation for duration test"
+    status = ReservationStatus.confirmed
+    new_reservation = Reservation(
+        start_time=start_time,
+        end_time=end_time,
+        customer_id=customer_id,
+        num_of_persons=num_of_persons,
+        comment=comment,
+        status=status
+    )
+    assert new_reservation.duration() == end_time - start_time

--- a/timeless/restaurants/models.py
+++ b/timeless/restaurants/models.py
@@ -130,13 +130,15 @@ class Reservation(TimestampsMixin, DB.Model):
     id = DB.Column(DB.Integer, primary_key=True, autoincrement=True)
     start_time = DB.Column(DB.DateTime, nullable=False)
     end_time = DB.Column(DB.DateTime, nullable=False)
-    duration = DB.Column(DB.Time, nullable=False)
     customer_id = DB.Column(DB.Integer, DB.ForeignKey("customers.id"))
     num_of_persons = DB.Column(DB.DateTime, nullable=False)
     comment = DB.Column(DB.String, nullable=False)
     status = DB.Column(DB.Enum(ReservationStatus), nullable=False)
 
     tables = DB.relationship("TableReservation", back_populates="reservation")
+
+    def duration(self):
+        return self.end_time - self.start_time
 
     def __repr__(self):
         return "<Reservation %r>" % self.id

--- a/timeless/restaurants/models.py
+++ b/timeless/restaurants/models.py
@@ -115,9 +115,6 @@ class Table(PosterSyncMixin, DB.Model):
 
 class Reservation(TimestampsMixin, DB.Model):
     """Model for a Reservation
-    @todo #27:30min Calculate reservation duration in constructor
-     by subtracting start_time and end_time. Don't forget to call super
-     constructor in order not to override DB.Model functionality.
     @todo #27:30min Continue implementation of views. Index and a
      view page should be created to list all reservations. In the
      index page there should be also a function to delete the reservation

--- a/timeless/restaurants/models.py
+++ b/timeless/restaurants/models.py
@@ -134,6 +134,7 @@ class Reservation(TimestampsMixin, DB.Model):
 
     tables = DB.relationship("TableReservation", back_populates="reservation")
 
+    """Calculates the duration of the reservation"""
     def duration(self):
         return self.end_time - self.start_time
 


### PR DESCRIPTION
For #171: Reservation duration calculation:
- Moved `Reservation` tests from `test_models.py` to `test_reservation.py`
- Added `Reservation.duration()` method and removed `Reservation.duration` field: this value should not be stored, but calculated.

I've chosen to not implement this calculation in constructor, instead created a method for its calculation, because we should not make these operation in class constructors.