### PR TITLE
For #269: Translate error in login codes

### DIFF
--- a/tests/integration/it_property_resource_test.py
+++ b/tests/integration/it_property_resource_test.py
@@ -16,8 +16,9 @@ class TestPropertyResource():
         """ Test if PropertyResource can return a value that exists"""
         assert (
             PropertyResource(
-                 directory=self.directory
-            ).get(self, "foundkey", "en_US") == "thevalue"
+                 directory=self.directory,
+                 locale="en_US"
+            ).get(self, "foundkey") == "thevalue"
         )
 
     @pytest.mark.skip(reason="PropertyResource not implemented yet")
@@ -27,8 +28,9 @@ class TestPropertyResource():
         """
         with pytest.raises(Exception, "Value not found for key"):
             PropertyResource(
-                directory=self.directory
-            ).get(self, "notfoundkey", "en_US")
+                directory=self.directory,
+                locale="en_US"
+            ).get(self, "notfoundkey",)
 
     @pytest.mark.skip(reason="PropertyResource not implemented yet")
     def test_get_found(self):
@@ -37,6 +39,7 @@ class TestPropertyResource():
         """
         assert (
             PropertyResource(
-                directory=self.directory
-            ).get(self, "foundkey", "pt_BR") == "ovalor"
+                directory=self.directory,
+                locale="pt_BR"
+            ).get(self, "foundkey") == "ovalor"
         )

--- a/tests/integration/it_property_resource_test.py
+++ b/tests/integration/it_property_resource_test.py
@@ -1,0 +1,42 @@
+""" Tests for PropertyResource, resource for internationalization based on a
+property file
+
+"""
+import pytest
+
+from timeless.message.property_resource import PropertyResource
+
+
+class TestPropertyResource():
+
+    directory = "resources/messages/"
+
+    @pytest.mark.skip(reason="PropertyResource not implemented yet")
+    def test_get_found(self):
+        """ Test if PropertyResource can return a value that exists"""
+        assert (
+            PropertyResource(
+                 directory=self.directory
+            ).get(self, "foundkey", "en_US") == "thevalue"
+        )
+
+    @pytest.mark.skip(reason="PropertyResource not implemented yet")
+    def test_get_not_found(self):
+        """ Test if PropertyResource returns exception when value does not
+        exist
+        """
+        with pytest.raises(Exception, "Value not found for key"):
+            PropertyResource(
+                directory=self.directory
+            ).get(self, "notfoundkey", "en_US")
+
+    @pytest.mark.skip(reason="PropertyResource not implemented yet")
+    def test_get_found(self):
+        """ Test if PropertyResource can return a value that exists from
+        localised file
+        """
+        assert (
+            PropertyResource(
+                directory=self.directory
+            ).get(self, "foundkey", "pt_BR") == "ovalor"
+        )

--- a/tests/integration/resources/messages/message_en_US.properties
+++ b/tests/integration/resources/messages/message_en_US.properties
@@ -1,0 +1,2 @@
+#commentedkey=commentedvalue
+foundkey=thevalue

--- a/tests/integration/resources/messages/message_pt_BR.properties
+++ b/tests/integration/resources/messages/message_pt_BR.properties
@@ -1,0 +1,2 @@
+#commentedkey=valorcomentado
+foundkey=ovalor

--- a/timeless/message/message_resource.py
+++ b/timeless/message/message_resource.py
@@ -4,5 +4,5 @@
 class MessageResource:
     """ Interface that defines behavior """
 
-    def get(self, key, locale):
+    def get(self, key):
         raise Exception("Message Resource does not implement methods!")

--- a/timeless/message/message_resource.py
+++ b/timeless/message/message_resource.py
@@ -6,4 +6,3 @@ class MessageResource:
 
     def get(self, key, locale):
         raise Exception("Message Resource does not implement methods!")
-

--- a/timeless/message/message_resource.py
+++ b/timeless/message/message_resource.py
@@ -1,0 +1,9 @@
+""" Message resource for internationalization """
+
+
+class MessageResource:
+    """ Interface that defines behavior """
+
+    def get(self, key, locale):
+        raise Exception("Message Resource does not implement methods!")
+

--- a/timeless/message/property_resource.py
+++ b/timeless/message/property_resource.py
@@ -1,0 +1,20 @@
+""" Message resource for internationalization based on a property file """
+
+from timeless.message.message_resource import MessageResource
+
+
+class PropertyResource(MessageResource):
+    """ Resources read from a property file.
+        @todo #269:30min Implement FileResource. FileResource should read a
+         property file and return the value according to the keys. Locale
+         should be used to define from which locale the file belongs. The
+         locale is defined in the fine name, for example,
+         messages_en_US.properties. An exception must be raised if some
+         resource is not found on property file. Then remove the skip
+         annotations from it_test_property_resource.py
+
+    """
+
+    def get(self, key, locale):
+        raise Exception("PropertyResources not implement yet!")
+

--- a/timeless/message/property_resource.py
+++ b/timeless/message/property_resource.py
@@ -15,5 +15,5 @@ class PropertyResource(MessageResource):
 
     """
 
-    def get(self, key, locale):
+    def get(self, key):
         raise Exception("PropertyResources not implement yet!")

--- a/timeless/message/property_resource.py
+++ b/timeless/message/property_resource.py
@@ -17,4 +17,3 @@ class PropertyResource(MessageResource):
 
     def get(self, key, locale):
         raise Exception("PropertyResources not implement yet!")
-


### PR DESCRIPTION
For #269: Translate error in login codes:
- Added `message_resource.py` with `MessageContract`, a contract defining the methods for resource providers;
- Added `property_resource.py` with `PropertyResource`, a property file based resource provider;
- Added tests for `PropertyResource`
- Left puzzle for `PropertyResource` implementation
