### PR TITLE
#204 Enabling CSRF protection

### DIFF
--- a/timeless/__init__.py
+++ b/timeless/__init__.py
@@ -1,5 +1,8 @@
 """This file contains all functions needed to create
 a new Flask app for timeless
+@todo #204:30min Continue implementing CSRF token protection for all create and
+ edit templates. Implementation detail you can find on the following page:
+ https://flask-wtf.readthedocs.io/en/stable/csrf.html
 """
 # Since if import models / views inside methods, pylint complains
 # about cyclic imports.
@@ -10,6 +13,7 @@ from flask import Flask
 from timeless.cache import CACHE
 from timeless.db import DB
 from timeless.sync.celery import make_celery
+from timeless.csrf import CSRF
 
 
 def create_app(config):
@@ -20,6 +24,7 @@ def create_app(config):
         app,
         config=app.config.get("CACHE_SETTINGS")
     )
+    CSRF.init_app(app)
     initialize_extensions(app)
     register_endpoints(app)
     # ensure the instance folder exists
@@ -70,6 +75,7 @@ def register_api(app, view, endpoint, url, pk="id", pk_type="int"):
 
 
 def register_endpoints(app):
+    """ Initalize application endpoints """
     from timeless.companies import views as companies_views
     from timeless.auth import views as auth_views
     from timeless.reservations import views as reservations_views

--- a/timeless/csrf/__init__.py
+++ b/timeless/csrf/__init__.py
@@ -1,0 +1,4 @@
+""" CSRF module """
+from flask_wtf.csrf import CSRFProtect
+
+CSRF = CSRFProtect()

--- a/timeless/restaurants/table_shapes/views.py
+++ b/timeless/restaurants/table_shapes/views.py
@@ -42,6 +42,8 @@ def create():
         @todo #162:30min This form currenly cannot save pictures. Need have a
          look how WTF form processes files. Implement generic solution to use
          it everywhere when it's needed.
+        """
+        """ 
         Uncomment after correction
         form.save()
         """

--- a/timeless/restaurants/table_shapes/views.py
+++ b/timeless/restaurants/table_shapes/views.py
@@ -38,12 +38,10 @@ def create():
     form = forms.TableShapeForm(request.form)
 
     if request.method == "POST" and form.validate():
-        """        
+        """
         @todo #162:30min This form currenly cannot save pictures. Need have a
          look how WTF form processes files. Implement generic solution to use
          it everywhere when it's needed.
-        """
-        """
         Uncomment after correction
         form.save()
         """

--- a/timeless/restaurants/table_shapes/views.py
+++ b/timeless/restaurants/table_shapes/views.py
@@ -43,7 +43,7 @@ def create():
          look how WTF form processes files. Implement generic solution to use
          it everywhere when it's needed.
         """
-        """ 
+        """
         Uncomment after correction
         form.save()
         """

--- a/timeless/restaurants/table_shapes/views.py
+++ b/timeless/restaurants/table_shapes/views.py
@@ -38,10 +38,7 @@ def create():
     form = forms.TableShapeForm(request.form)
 
     if request.method == "POST" and form.validate():
-        """
-        @todo #162:30min Initialize CSRF token protection for app and add
-         token to this template. Implementation detail you can find by the
-         following page: https://flask-wtf.readthedocs.io/en/stable/csrf.html
+        """        
         @todo #162:30min This form currenly cannot save pictures. Need have a
          look how WTF form processes files. Implement generic solution to use
          it everywhere when it's needed.

--- a/timeless/templates/restaurants/table_shapes/create_edit.html
+++ b/timeless/templates/restaurants/table_shapes/create_edit.html
@@ -12,5 +12,6 @@
     <p>
       <button type="submit">Create</button>
     </p>
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
   </form>
 {% endblock %}


### PR DESCRIPTION
For #204:

- Enabling CSRF protection in application
- Implementing for table shapes's `create_edit` template
- Leaving puzzle to continue implementation for other templates