### PR TITLE
For #242: Owner privileges over user tests

### DIFF
--- a/tests/integration/it_owner_privileges_test.py
+++ b/tests/integration/it_owner_privileges_test.py
@@ -192,16 +192,16 @@ def test_can_manage_employees_from_same_company(clean_app, db_session):
     db_session.add(employee)
     db_session.commit()
     assert has_privilege(
-        method=Method.READ, resource="employee", id=employee.id
+        method=Method.READ, resource="employee", employee_id=employee.id
     )
     assert has_privilege(
         method=Method.CREATE, resource="employee"
     )
     assert has_privilege(
-        method=Method.UPDATE, resource="employee", id=employee.id
+        method=Method.UPDATE, resource="employee", employee_id=employee.id
     )
     assert has_privilege(
-        method=Method.DELETE, resource="employee", id=employee.id
+        method=Method.DELETE, resource="employee", employee_id=employee.id
     )
 
 
@@ -264,14 +264,14 @@ def test_can_not_manage_employees_from_different_company(clean_app, db_session):
     db_session.add(employee)
     db_session.commit()
     assert not has_privilege(
-        method=Method.READ, resource="employee", id=employee.id
+        method=Method.READ, resource="employee", employee_id=employee.id
     )
     assert not has_privilege(
         method=Method.CREATE, resource="employee"
     )
     assert not has_privilege(
-        method=Method.UPDATE, resource="employee", id=employee.id
+        method=Method.UPDATE, resource="employee", employee_id=employee.id
     )
     assert not has_privilege(
-        method=Method.DELETE, resource="employee", id=employee.id
+        method=Method.DELETE, resource="employee", employee_id=employee.id
     )

--- a/tests/integration/it_owner_privileges_test.py
+++ b/tests/integration/it_owner_privileges_test.py
@@ -146,7 +146,7 @@ def test_can_not_manage_locations_from_different_company(clean_app, db_session):
         method=Method.DELETE, resource="location", id=location.id
     )
 
-
+@pytest.mark.skip(reason="Implement owner privileges to check for company")
 def test_can_manage_employees_from_same_company(clean_app, db_session):
     my_company = Company(
         name="Mothers Of Invention Inc.", code="code1", address="addr"
@@ -175,8 +175,22 @@ def test_can_manage_employees_from_same_company(clean_app, db_session):
         role_id=role.id
     )
     db_session.add(boss)
+    db_session.commit()
     flask.g.user = boss
-    employee = factories.EmployeeFactory(company=my_company)
+    employee = Employee(
+        first_name="Jack", last_name="Black",
+        username="jack", phone_number="1",
+        birth_date=datetime.utcnow(),
+        pin_code=5648,
+        account_status="on",
+        user_status="on",
+        registration_date=datetime.utcnow(),
+        company_id=my_company.id,
+        email="jack@black.com",
+        password="bla"
+    )
+    db_session.add(employee)
+    db_session.commit()
     assert has_privilege(
         method=Method.READ, resource="employee", id=employee.id
     )

--- a/tests/integration/it_owner_privileges_test.py
+++ b/tests/integration/it_owner_privileges_test.py
@@ -1,4 +1,4 @@
-""" Tests for privilage of user.
+''""" Tests for privilege of owner.
 """
 
 from datetime import datetime
@@ -141,4 +141,102 @@ def test_can_not_manage_locations_from_different_company(clean_app, db_session):
     )
     assert not has_privilege(
         method=Method.DELETE, resource="location", id=location.id
+    )
+
+
+def test_can_manage_users_from_same_company(clean_app, db_session):
+    my_company = Company(
+        name="Mothers Of Invention Inc.", code="code1", address="addr"
+    )
+    db_session.add(my_company)
+    db_session.commit()
+    boss = Employee(
+        first_name="Frank", last_name="Zappa",
+        username="frank", phone_number="1",
+        birth_date=datetime.utcnow(),
+        pin_code=7777,
+        account_status="on",
+        user_status="on",
+        registration_date=datetime.utcnow(),
+        company_id=my_company.id,
+        email="fank@mothers.com", password="bla"
+    )
+    db_session.add(boss)
+    flask.g.user = boss
+    employee = Employee(
+        first_name="Uncle", last_name="Remus",
+        username="stinkfoot", phone_number="1",
+        birth_date=datetime.utcnow(),
+        pin_code=7777,
+        account_status="on",
+        user_status="on",
+        registration_date=datetime.utcnow(),
+        company_id=my_company.id,
+        email="remus@mothers.com", password="bla"
+    )
+    db_session.add(employee)
+    db_session.commit()
+    assert has_privilege(
+        method=Method.READ, resource="employee", id=employee.id
+    )
+    assert has_privilege(
+        method=Method.CREATE, resource="location", id=employee.id
+    )
+    assert has_privilege(
+        method=Method.UPDATE, resource="location", id=employee.id
+    )
+    assert has_privilege(
+        method=Method.DELETE, resource="location", id=employee.id
+    )
+
+
+def test_can_not_manage_locations_from_different_company(clean_app, db_session):
+    boss_company = Company(
+        name="Mothers Of Invention Inc.", code="code1", address="addr"
+    )
+    db_session.add(boss_company)
+    db_session.commit()
+    boss = Employee(
+        first_name="Frank", last_name="Zappa",
+        username="frank", phone_number="1",
+        birth_date=datetime.utcnow(),
+        pin_code=7777,
+        account_status="on",
+        user_status="on",
+        registration_date=datetime.utcnow(),
+        company_id=boss_company.id,
+        email="fank@mothers.com", password="bla"
+    )
+    db_session.add(boss)
+    flask.g.user = boss
+
+    employee_company = Company(
+        name="Damage Inc.", code="code2", address="addr"
+    )
+    db_session.add(employee_company)
+    db_session.commit()
+    employee = Employee(
+        first_name="James", last_name="Hetfield",
+        username="jaymz", phone_number="1",
+        birth_date=datetime.utcnow(),
+        pin_code=7777,
+        account_status="on",
+        user_status="on",
+        registration_date=datetime.utcnow(),
+        company_id=employee_company.id,
+        email="jaymz@metallica.com", password="bla"
+    )
+    db_session.add(employee)
+    db_session.commit()
+    assert not has_privilege(
+        method=Method.READ, resource="employee", id=employee.id
+    )
+    assert not has_privilege(
+        method=Method.CREATE, resource="location", id=employee.id
+    )
+    assert not has_privilege(
+        method=Method.UPDATE, resource="location", id=employee.id
+    )
+    assert not has_privilege(
+        method=Method.DELETE, resource="location", id=employee.id
     )

--- a/tests/integration/it_owner_privileges_test.py
+++ b/tests/integration/it_owner_privileges_test.py
@@ -165,7 +165,7 @@ def test_can_manage_employees_from_same_company(clean_app, db_session):
         first_name="Frank", last_name="Zappa",
         username="frank", phone_number="1",
         birth_date=datetime.utcnow(),
-        pin_code=7777,
+        pin_code=1248,
         account_status="on",
         user_status="on",
         registration_date=datetime.utcnow(),
@@ -191,6 +191,7 @@ def test_can_manage_employees_from_same_company(clean_app, db_session):
     )
 
 
+@pytest.mark.skip(reason="Implement owner privileges to check for company")
 def test_can_not_manage_employees_from_different_company(clean_app, db_session):
     boss_company = Company(
         name="Mothers Of Invention Inc.", code="code1", address="addr"
@@ -209,18 +210,17 @@ def test_can_not_manage_employees_from_different_company(clean_app, db_session):
         first_name="Frank", last_name="Zappa",
         username="frank", phone_number="1",
         birth_date=datetime.utcnow(),
-        pin_code=7777,
+        pin_code=6547,
         account_status="on",
         user_status="on",
         registration_date=datetime.utcnow(),
         company_id=boss_company.id,
         email="fank@mothers.com",
         password="bla",
-        role=owner_role.id
+        role_id=owner_role.id
     )
     db_session.add(boss)
     flask.g.user = boss
-
     employee_company = Company(
         name="Damage Inc.", code="code2", address="addr"
     )
@@ -245,7 +245,7 @@ def test_can_not_manage_employees_from_different_company(clean_app, db_session):
         company_id=employee_company.id,
         email="jaymz@metallica.com",
         password="bla",
-        role=employee_role.id
+        role_id=employee_role.id
     )
     db_session.add(employee)
     db_session.commit()

--- a/timeless/access_control/authorization.py
+++ b/timeless/access_control/authorization.py
@@ -12,7 +12,12 @@ def is_allowed(method=None, resource=None, *args, **kwargs) -> bool:
     @todo #22:30min Get role from actual user instead of using
      hardcoded value. User can be fetched from g.user. Make sure
      that access is not allowed for unknown role.
+    @todo #242:30min Implement the rest of the owner privileges.
+     Owner should be able to create, modify, activate and deactivate accounts
+     for employess of his/her company. Create the tests for each of this
+     operation..
     """
+
     return __roles.get("owner").has_privilege(
         method=method, resource=resource, args=args, kwargs=kwargs
     )

--- a/timeless/access_control/owner_privileges.py
+++ b/timeless/access_control/owner_privileges.py
@@ -5,11 +5,7 @@ from timeless.restaurants.models import Location
 
 
 def has_privilege(method=None, resource=None, *args, **kwargs) -> bool:
-    """Check if user with Owner role can access a particular resource.
-    @todo #180:30min Implement the rest of the owner privileges.
-     1) Create /modify /activate /deactivate accounts for all Employee
-     associated with owned Company
-    """
+    """Check if user with Owner role can access a particular resource."""
     return __resources.get(resource, lambda *arg: False)(method, *args, **kwargs)
 
 

--- a/timeless/access_control/owner_privileges.py
+++ b/timeless/access_control/owner_privileges.py
@@ -4,11 +4,13 @@ from timeless.access_control.methods import Method
 from timeless.restaurants.models import Location
 
 """
-    @todo #242:30min Implement owner privileges regarding company. Owner 
-     should be able to operate over employees of his own company only. Implement
-     this rules on __employee_access and then uncomment tests from 
+    @todo #242:30min Implement owner privileges regarding company. Owner
+     should be able to operate over employees of his own company only.
+     Implement this rules on __employee_access and then uncomment tests from
      owner_privileges.py
 """
+
+
 def has_privilege(method=None, resource=None, *args, **kwargs) -> bool:
     """Check if user with Owner role can access a particular resource."""
     return __resources.get(resource, lambda *arg: False)(method, *args, **kwargs)

--- a/timeless/access_control/owner_privileges.py
+++ b/timeless/access_control/owner_privileges.py
@@ -3,7 +3,12 @@ import flask
 from timeless.access_control.methods import Method
 from timeless.restaurants.models import Location
 
-
+"""
+    @todo #242:30min Implement owner privileges regarding company. Owner 
+     should be able to operate over employees of his own company only. Implement
+     this rules on __employee_access and then uncomment test from 
+     owner_privileges.py:test_can_not_manage_employees_from_different_company
+"""
 def has_privilege(method=None, resource=None, *args, **kwargs) -> bool:
     """Check if user with Owner role can access a particular resource."""
     return __resources.get(resource, lambda *arg: False)(method, *args, **kwargs)

--- a/timeless/access_control/owner_privileges.py
+++ b/timeless/access_control/owner_privileges.py
@@ -6,8 +6,8 @@ from timeless.restaurants.models import Location
 """
     @todo #242:30min Implement owner privileges regarding company. Owner 
      should be able to operate over employees of his own company only. Implement
-     this rules on __employee_access and then uncomment test from 
-     owner_privileges.py:test_can_not_manage_employees_from_different_company
+     this rules on __employee_access and then uncomment tests from 
+     owner_privileges.py
 """
 def has_privilege(method=None, resource=None, *args, **kwargs) -> bool:
     """Check if user with Owner role can access a particular resource."""


### PR DESCRIPTION
For #242: Owner privileges over user tests
- Added `test_can_manage_users_from_same_company` and `test_cant_manage_users_from_same_company` tests
- Left puzzle for continue implementation